### PR TITLE
fix for multi strings/bytes packing/unpacking

### DIFF
--- a/abi/lengths.go
+++ b/abi/lengths.go
@@ -2,8 +2,9 @@ package abi
 
 var (
 	lengths = map[string]int{
-		"string":   32, // hack. this is currently a reserved word in solidity https://ethereumbuilders.gitbooks.io/guide/content/en/solidity_features.html#hashxx-and-stringxx-to-bytesxx
-		"bytes":    32, // hack. this is currently a reserved word in solidity https://ethereumbuilders.gitbooks.io/guide/content/en/solidity_features.html#byte-arrays
+		"retBlock": 32,
+		"string":   32,
+		"bytes":    32,
 		"byte":     1,
 		"bytes1":   1,
 		"bytes2":   2,
@@ -137,6 +138,5 @@ var (
 		"int256":   32,
 		"bool":     32,
 		"address":  20,
-		"retBlock": 32,
 	}
 )


### PR DESCRIPTION
fixes problem with abi packing which was not in line with abi specification as to populating dynamic length arguments. 

adds a struct to allow for more logical handing of both static and dynamic arguments. both have been handled for the packing process at this point. 

TODO: test this on the unpacking side (I'm not sure if it will have the weird mixed packing that the packing spec has). 